### PR TITLE
Upgrade to version 88.0.4324.33

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 # Contributor: Mateus Rodrigues Costa <charles [dot] costar [at] gmail [dot] com>
 
 pkgname=chrome-remote-desktop
-pkgver=88.0.4324.9
+pkgver=88.0.4324.33
 pkgrel=1
 pkgdesc="Access other computers or allow another user to access your computer securely over the Internet"
 arch=("x86_64")
@@ -20,7 +20,7 @@ source=(
   "crd"
 )
 sha256sums=(
-  "daab52c9be410a6a07e4165e5dadb48f4e0fd693e37bd68e18c2a1781cb508fc"
+  "671f1ed6edb0466ccf054779e48ee411d5e0abffe4ec25975157ea646a05ec38"
   "e5da5ae89b5bc599f72f415d1523341b25357931b0de46159fce50ab83615a4b"
   "fcc38269eb1cc902abff9688eda9377a22367e39b9f111f87c0dd8e77adb82e2"
   "27dee2d383e6bd993fe0557d5c222fa80ab6d16d43775dedff6218713c7a1c06"


### PR DESCRIPTION
Update version string and checksum so that the latest version could be installed. The old version currently returns a 404 and can no longer be installed.