### PR TITLE
feat: upgrade version to latest on Package from Google

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 # Contributor: Mateus Rodrigues Costa <charles [dot] costar [at] gmail [dot] com>
 
 pkgname=chrome-remote-desktop
-pkgver=110.0.5481.14
+pkgver=111.0.5563.12
 pkgrel=1
 pkgdesc="Access other computers or allow another user to access your computer securely over the Internet"
 arch=("x86_64")
@@ -20,7 +20,7 @@ source=(
   "crd"
 )
 sha256sums=(
-  "aa5726a9a8e7acc73e94a347ae9a60256b594b96a478b6f70387f091abadd712"
+  "85283f18c8ee012ce572519a94c42b2041b8fb28fa7ddc2c132d670d6931bbe7"
   "e5da5ae89b5bc599f72f415d1523341b25357931b0de46159fce50ab83615a4b"
   "fcc38269eb1cc902abff9688eda9377a22367e39b9f111f87c0dd8e77adb82e2"
   "021110f49d465294517eec92eeb24ebca41e264ef33cbdda78732add1f269d02"


### PR DESCRIPTION
Get version 111.0.5563.12 from file downlodead in :https://dl.google.com/linux/chrome-remote-desktop/deb/dists/stable/main/binary-amd64/Packages

Update version and SHA256